### PR TITLE
Port to Sphinx 8.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,6 +169,6 @@ texinfo_documents = [
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {"python": ("https://docs.python.org/", None)}
 autodoc_member_order = "bysource"
 add_module_names = False


### PR DESCRIPTION
The old `intersphinx_mapping` format has been removed; it must now map identifiers to (target, inventory) tuples.